### PR TITLE
add: context7 MCP server definition

### DIFF
--- a/core/mcp-servers/context7.json
+++ b/core/mcp-servers/context7.json
@@ -1,0 +1,9 @@
+{
+  "name": "context7",
+  "type": "remote",
+  "url": "https://mcp.context7.com/mcp",
+  "enabled": true,
+  "headers": {
+    "CONTEXT7_API_KEY": "YOUR_API_KEY"
+  }
+}


### PR DESCRIPTION
Adds a remote MCP server config for Context7 at core/mcp-servers/context7.json.\n\n- URL: https://mcp.context7.com/mcp\n- Header: CONTEXT7_API_KEY placeholder\n\nReplace the placeholder with a real API key or configure via your secrets store.